### PR TITLE
[ci] Add workflow to publish package to pub.dev manually

### DIFF
--- a/.github/workflows/pubdev-publishing-manually.yml
+++ b/.github/workflows/pubdev-publishing-manually.yml
@@ -1,0 +1,39 @@
+name: Publish to Pub.dev 🚀
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: The branch to be released
+        type: string
+        required: true
+        default: 'main'
+
+jobs:
+  publishing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.release_branch }}
+      - name: Get tags
+        run: git fetch --tags origin
+      - name: Check Versions 🔎
+        run: |
+          set -eo pipefail
+          export LIB_VERSION=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "LIB_VERSION: ${LIB_VERSION}"
+          export PUBSPEC_VERSION=$(grep 'version: ' pubspec.yaml | sed -e 's,.*: \(.*\),\1,')
+          echo "PUBSPEC_VERSION: ${PUBSPEC_VERSION}"
+          if [ "$LIB_VERSION" != "${PUBSPEC_VERSION}" ]; then
+            echo "Version in 'pubspec.yaml' does not match tag.";
+            exit 1;
+          fi
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Publish
+        run: dart pub publish --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  publish_pub: # See https://dart.dev/tools/pub/automated-publishing#configuring-a-github-action-workflow-for-publishing-to-pub-dev
+  publish_pub:
     name: Publish to pub.dev
     needs: release_if_merged
+    runs-on: ubuntu-latest
+    # See https://dart.dev/tools/pub/automated-publishing#configuring-a-github-action-workflow-for-publishing-to-pub-dev
     permissions:
       id-token: write # Required for authentication using OIDC
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    steps:
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Publish
+        run: dart pub publish --force


### PR DESCRIPTION
The previous publish job failed https://github.com/littleGnAl/glance/actions/runs/11038962477/job/30663395103, need to publish the package to pub.dev manually.