### PR TITLE
Set kDefaultSampleRateInMilliseconds to 10ms

### DIFF
--- a/example/glance_integration_test/build_phase_jank_test.dart
+++ b/example/glance_integration_test/build_phase_jank_test.dart
@@ -60,8 +60,6 @@ void main() {
     await Glance.instance.start(
       config: GlanceConfiguration(
         reporters: [reporter],
-        jankThreshold: 5,
-        sampleRateInMilliseconds: 1,
       ),
     );
 

--- a/example/glance_integration_test/touch_event_jank_test.dart
+++ b/example/glance_integration_test/touch_event_jank_test.dart
@@ -98,7 +98,6 @@ void main() {
     await Glance.instance.start(
       config: GlanceConfiguration(
         reporters: [reporter],
-        jankThreshold: 5,
       ),
     );
 

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -2,7 +2,7 @@
 const int kDefaultJankThreshold = 16;
 
 /// The default sample rate for measuring performance in milliseconds.
-const int kDefaultSampleRateInMilliseconds = 1;
+const int kDefaultSampleRateInMilliseconds = 10;
 
 /// Limits the maximum number of stack traces to 99. Any stack traces exceeding
 /// `kMaxStackTraces` will be dropped.


### PR DESCRIPTION
During UI jank, even if a high sampling rate is not required, we can still collect relatively accurate stack traces. So, we have adjusted the `kDefaultSampleRateInMilliseconds` to 10ms to reduce the performance overhead.