### PR TITLE
[ci] Fix WARNING elimination logic of releast-it and change types to the same section: Changes

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -39,9 +39,9 @@ jobs:
       - name: Run release-it
         id: release_it_step
         run: |
-          # Eliminate the warning: WARNING The recommended bump is "patch", but is overridden with "xxx".
+          # Eliminate the warning: WARNING The recommended bump is "xxx", but is overridden with "xxx".
           # Adding `ignoreRecommendedBump` to the `.release-it.json` file is not work for me. Use `grep` to filter it.
-          CHANGELOG=$(release-it ${{ inputs.version }} --changelog  2>&1 | grep -Pv 'WARNING The recommended bump is "patch",.*')
+          CHANGELOG=$(release-it ${{ inputs.version }} --changelog  2>&1 | grep -Pv 'WARNING The recommended bump is.*')
           echo "The CHANGELOG: ${CHANGELOG}"
           # https://github.com/orgs/community/discussions/26288#discussioncomment-3876281
           delimiter="EOF"

--- a/.release-it.json
+++ b/.release-it.json
@@ -9,14 +9,15 @@
         "types": [
           {
             "type": "feat",
-            "section": "Features"
+            "section": "Changes"
           },
           {
             "type": "fix",
-            "section": "Bug Fixes"
+            "section": "Changes"
           },
           {
-            "type": "chore"
+            "type": "chore",
+            "section": "Changes"
           }
         ]
       }


### PR DESCRIPTION
* Fix WARNING elimination logic of `releast-it`, fixed match of `WARNING The recommended bump is "major", but is overridden with "xxx.`
* Change `types` to the same section: Changes.