### PR TITLE
[ci][pubdev-publishing.yml] Only triggered for push tags event

### DIFF
--- a/.github/workflows/pubdev-publishing.yml
+++ b/.github/workflows/pubdev-publishing.yml
@@ -4,14 +4,6 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+' # '0.2.0'
-      
-  workflow_dispatch:
-    inputs:
-      release_branch:
-        description: The branch to be released
-        type: string
-        required: true
-        default: 'main'
 
 jobs:
   publishing: # See https://dart.dev/tools/pub/automated-publishing#configuring-a-github-action-workflow-for-publishing-to-pub-dev
@@ -19,14 +11,7 @@ jobs:
     permissions:
         id-token: write # Required for authentication using OIDC
     steps:
-      - name: Checkout for workflow_dispatch
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.release_branch }}
-          fetch-depth: 0
       - name: Checkout for push tags
-        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v4
 
       # Sets the GitHub-signed OIDC token


### PR DESCRIPTION
The workflow was not triggered when mixing `push` and `workflow_dispatch ` events, and the implementation is still not working for the `workflow_dispatch` event(failed job https://github.com/littleGnAl/glance/actions/runs/11128320432/job/30922768729), so I decided to only keep the `push` event at this time.
