### PR TITLE
chore: Optimize memory usage for stack capture

### DIFF
--- a/lib/src/sampler.dart
+++ b/lib/src/sampler.dart
@@ -231,6 +231,7 @@ class SamplerProcessor {
   void close() {
     isRunning = false;
     _buffer = null;
+    _stackCapturer.dispose();
   }
 
   /// Aggregate the [NativeFrame]s by occurrence times.

--- a/test/sampler_test.dart
+++ b/test/sampler_test.dart
@@ -68,6 +68,7 @@ SamplerProcessorFactory _samplerProcessorFactory(
 class FakeStackCapturer implements StackCapturer {
   bool isCaptureStackOfTargetThread = false;
   bool isSetCurrentThreadAsTarget = false;
+  bool isDisposed = false;
   NativeStack nativeStack = NativeStack(frames: [], modules: []);
 
   @override
@@ -79,6 +80,11 @@ class FakeStackCapturer implements StackCapturer {
   @override
   void setCurrentThreadAsTarget() {
     isSetCurrentThreadAsTarget = true;
+  }
+
+  @override
+  void dispose() {
+    isDisposed = true;
   }
 }
 
@@ -419,6 +425,7 @@ void main() {
       );
       samplerProcessor.close();
       expect(samplerProcessor.isRunning, isFalse);
+      expect(stackCapturer.isDisposed, isTrue);
     });
 
     group('aggregateStacks', () {


### PR DESCRIPTION
- The maximum stack depth of 1024 bytes is a bit wasteful, adjusting it to 100 is already sufficient for our needs.
- Introduce a global buffer to reuse and reduce memory fluctuations.