### PR TITLE
[ci] Ping the latest Flutter SDK version to 3.29.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: '3.29.0'
       - name: Check Dart Format
         run: |
           if ! dart format --output=none --set-exit-if-changed .; then
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
+          flutter-version: '3.29.0'
       - run: flutter test
 
   android_smoke_build:
@@ -54,7 +54,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       matrix:
-        version: ["3.10.0", "3.x"]
+        version: ["3.10.0", "3.29.0"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -76,7 +76,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       matrix:
-        version: ["3.10.0", "3.x"]
+        version: ["3.10.0", "3.29.0"]
     runs-on: macos-12
     timeout-minutes: 120
     steps:
@@ -95,7 +95,7 @@ jobs:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci:skip') }}
     strategy:
       matrix:
-        version: ['3.x']
+        version: ['3.29.0']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Ping the latest Flutter SDK version to the specific version (currently 3.29.0) to avoid the CI breaks when a newer Flutter SDK is released.