### PR TITLE
[ci] Refactor pub.dev check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,12 +32,12 @@ jobs:
           INPUT_MINANNOTATIONLEVEL: info
         run: |
           flutter doctor
-          flutter pub global activate pana
+          dart pub global activate pana
 
           git clone https://github.com/axel-op/dart-package-analyzer.git -b stable $HOME/dart-package-analyzer
           cd $HOME/dart-package-analyzer/app
 
-          flutter pub get
+          dart pub get
           dart bin/main.dart
       - name: Check scores
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           flutter doctor
           dart pub global activate pana
 
-          git clone https://github.com/axel-op/dart-package-analyzer.git -b stable $HOME/dart-package-analyzer
+          git clone https://github.com/axel-op/dart-package-analyzer.git -b v3 $HOME/dart-package-analyzer
           cd $HOME/dart-package-analyzer/app
 
           dart pub get

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,10 +25,20 @@ jobs:
       #       echo "Make sure you follow the dart code style (https://github.com/dart-lang/dart_style)."
       #       exit 1
       #     fi
-      - uses: axel-op/dart-package-analyzer@v3
+      - name: Run Dart Package Analyzer
         id: analysis
-        with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          INPUT_GITHUBTOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_MINANNOTATIONLEVEL: info
+        run: |
+          flutter doctor
+          flutter pub global activate pana
+
+          git clone https://github.com/axel-op/dart-package-analyzer.git -b stable $HOME/dart-package-analyzer
+          cd $HOME/dart-package-analyzer/app
+
+          flutter pub get
+          dart bin/main.dart
       - name: Check scores
         env:
           TOTAL: ${{ steps.analysis.outputs.total }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,8 @@ jobs:
           flutter doctor
           dart pub global activate pana
 
-          git clone https://github.com/axel-op/dart-package-analyzer.git -b v3 $HOME/dart-package-analyzer
+          # 56afb7e6737bd2b7cee05382ae7f0e8111138080 is the stable commit we tested.
+          git clone https://github.com/axel-op/dart-package-analyzer.git -b $HOME/dart-package-analyzer 56afb7e6737bd2b7cee05382ae7f0e8111138080
           cd $HOME/dart-package-analyzer/app
 
           dart pub get

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,9 +34,10 @@ jobs:
           flutter doctor
           dart pub global activate pana
 
-          # 56afb7e6737bd2b7cee05382ae7f0e8111138080 is the stable commit we tested.
-          git clone https://github.com/axel-op/dart-package-analyzer.git -b $HOME/dart-package-analyzer 56afb7e6737bd2b7cee05382ae7f0e8111138080
+          git clone https://github.com/axel-op/dart-package-analyzer.git -b master $HOME/dart-package-analyzer
           cd $HOME/dart-package-analyzer/app
+          # 56afb7e6737bd2b7cee05382ae7f0e8111138080 is the stable commit we tested.
+          git checkout 56afb7e6737bd2b7cee05382ae7f0e8111138080
 
           dart pub get
           dart bin/main.dart


### PR DESCRIPTION
The [dart-package-analyzer](https://github.com/axel-op/dart-package-analyzer.git) seems to be not actively maintained, which is blocking this https://github.com/littleGnAl/glance/pull/65.

Run the [dart-package-analyzer](https://github.com/axel-op/dart-package-analyzer.git) directly rather than using the GitHub action by following https://github.com/axel-op/dart-package-analyzer/issues/5. It also allows us to fine-grained control of the pub.dev check in the future.