### PR TITLE
Fix: Correct working directory for package resolution in iOS smoke build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,7 +100,9 @@ jobs:
         with:
           flutter-version: ${{ matrix.version }}
           cache: true
-      - run: flutter packages get -v
+      - name: Get packages for example app
+        run: flutter packages get -v
+        working-directory: example
       - name: Run flutter build ios --no-codesign
         run: flutter build ios --no-codesign
         working-directory: example


### PR DESCRIPTION
Failed job: https://github.com/littleGnAl/glance/actions/runs/15158653850/job/42619382303?pr=69

The `flutter packages get -v` command in the `ios_smoke_build` job was running in the root directory, while the build itself was performed in the `example` directory. This caused issues with resolving the path dependency `path: ../` for the `glance` package in the example app's `pubspec.yaml`.

This commit changes the working directory of the `flutter packages get -v` command to `example`, ensuring that dependencies are resolved correctly for the example app before the build process.